### PR TITLE
Fix dt timeseries index reference/graph rendering.

### DIFF
--- a/client/js/controllers.js
+++ b/client/js/controllers.js
@@ -11,7 +11,7 @@
 		let loadChart = (options = {}) => {
 			chart.fetch().then(function(response){
 				let dbData = response.data.records,
-					dataSet = ['x', 'SYS', 'DIA', 'Pulse'];
+					dataSet = ['SYS', 'DIA', 'Pulse', 'x'];
 
 				//transpose data (swap columns and rows)
 				dbData = utils.transpose(dbData);
@@ -42,10 +42,10 @@
 		$scope.updateSelection = () => {
 			if ($scope.select !== "all"){
 				let dt;
-				chartData = [["x"],["SYS"],["DIA"],["Pulse"]];
+				chartData = [["SYS"],["DIA"],["Pulse"],["x"]];
 			
 				for (let indx = 1; indx < srcChartData[0].length; indx++){
-					dt = new Date(srcChartData[0][indx]);
+					dt = new Date(srcChartData[3][indx]);
 					if (($scope.select === "am" && dt.getHours() < 12) || ($scope.select === "pm" && dt.getHours() >= 12)){
 						for (let indy = 0; indy <= 3; indy++){
 							chartData[indy].push(srcChartData[indy][indx]);

--- a/client/js/directives.js
+++ b/client/js/directives.js
@@ -88,11 +88,12 @@
 						time;
 
 					//Check if row data is valid
-					if ($scope.bpTableForm["date" + rowNo].$invalid || 
-						$scope.bpTableForm["time" + rowNo].$invalid || 
+					if (
 						$scope.bpTableForm["sys" + rowNo].$invalid || 
 						$scope.bpTableForm["dia" + rowNo].$invalid || 
-						$scope.bpTableForm["pulse" + rowNo].$invalid
+						$scope.bpTableForm["pulse" + rowNo].$invalid ||
+						$scope.bpTableForm["date" + rowNo].$invalid || 
+						$scope.bpTableForm["time" + rowNo].$invalid
 					){
 						return;
 					}

--- a/public/js/bpr.js
+++ b/public/js/bpr.js
@@ -41,7 +41,7 @@ var kmBpr = angular.module("kmBpr", ['ngRoute', 'ui.bootstrap', 'ngSanitize', 'n
 
 			chart.fetch().then(function (response) {
 				var dbData = response.data.records,
-				    dataSet = ['x', 'SYS', 'DIA', 'Pulse'];
+				    dataSet = ['SYS', 'DIA', 'Pulse', 'x'];
 
 				//transpose data (swap columns and rows)
 				dbData = utils.transpose(dbData);
@@ -71,10 +71,10 @@ var kmBpr = angular.module("kmBpr", ['ngRoute', 'ui.bootstrap', 'ngSanitize', 'n
 		$scope.updateSelection = function () {
 			if ($scope.select !== "all") {
 				var dt = undefined;
-				chartData = [["x"], ["SYS"], ["DIA"], ["Pulse"]];
+				chartData = [["SYS"], ["DIA"], ["Pulse"], ["x"]];
 
 				for (var indx = 1; indx < srcChartData[0].length; indx++) {
-					dt = new Date(srcChartData[0][indx]);
+					dt = new Date(srcChartData[3][indx]);
 					if ($scope.select === "am" && dt.getHours() < 12 || $scope.select === "pm" && dt.getHours() >= 12) {
 						for (var indy = 0; indy <= 3; indy++) {
 							chartData[indy].push(srcChartData[indy][indx]);


### PR DESCRIPTION
# Graph time-series render bug

Minor change fixing problems reported in issue https://github.com/rulerofthedeities/BPR/issues/1 while maintaining the current features and functionality.

The issue started with hash 87010d655ac7a7547557b6d56d167fe7514e5f73 because 272d19bf6ea279c0aec85c480f87348b0669a081 (previous commit) does not show symptoms of this bug.
## Illustration: Bug Behavior

![No timeseries axis](http://i.imgur.com/DlXd54F.png)
## Pathology

This bug exhibits errors in the developer console on Chrome. It looks like the values of systolic bloodpressure are being provided as `Date` objects and failing to render the `x` series objects.

**Developer Console**
`Failed to parse x '150' to Date objecti.parseDate @ vendor.js:29069`
`Failed to parse x '145' to Date objecti.parseDate @ vendor.js:29069`
`Failed to parse x '140' to Date objecti.parseDate @ vendor.js:29069`
`Failed to parse x '153' to Date objecti.parseDate @ vendor.js:29069`
`Failed to parse x '149' to Date objecti.parseDate @ vendor.js:29069`
## Solution

I'm not really sure why this fixes the render bug. I'm thinking maybe the x timeseries **must be the last index** because of the way d3/c3 library uses the structure. 

I was expecting an index ['3'] to be referenced somewhere before datetime code runs. But all relevant code points to index ['0']. This refactor works appropriately to address the bug.
## Testing

This is a non breaking change. The behavior of the frontend does not change at all. **(Tested functionality of add records, all records, export functionality, and graph page) All renders OK.**

The application has been deployed on Heroku. The graph is confirmed to show timeseries data properly.
